### PR TITLE
Hoping this is good to go for version 0.9.7

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -8,7 +8,7 @@ Description: Simple URLs is a complete URL management system that allows you cre
 Author: Nathan Rice
 Author URI: http://www.nathanrice.net/
 
-Version: 0.9.6
+Version: 0.9.7
 
 Text Domain: simple-urls
 Domain Path: /languages
@@ -45,6 +45,8 @@ class SimpleURLs {
 	function register_post_type() {
 
 		$slug = 'surl';
+		
+		$rewrite_slug_default = 'go';
 
 		$labels = array(
 			'name'               => __( 'Simple URLs', 'simple-urls' ),
@@ -77,16 +79,24 @@ class SimpleURLs {
 
 		$labels = apply_filters( 'simple_urls_cpt_labels', $labels );
 
-		$rewrite_slug = apply_filters( 'simple_urls_slug', 'go' );
-
+		$rewrite_slug = apply_filters( 'simple_urls_slug', $rewrite_slug_default );
+		
+		$rewrite_slug = sanitize_title( $rewrite_slug, $rewrite_slug_default );
+		
+		// Ref: https://developer.wordpress.org/reference/functions/add_post_type_support/
+		$supports_array = apply_filters( 'simple_urls_post_type_supports', array( 'title' ) );
+    
+    // Ref: https://developer.wordpress.org/reference/functions/register_post_type/
 		register_post_type( $slug,
 			array(
-				'labels'        => $labels,
-				'public'        => true,
-				'query_var'     => true,
-				'menu_position' => 20,
-				'supports'      => array( 'title' ),
-				'rewrite'       => array( 'slug' => $rewrite_slug, 'with_front' => false ),
+				'labels'              => $labels,
+				'public'              => false,
+				'exclude_from_search' => apply_filters( 'simple_urls_exclude_from_search', true ),
+				'show_ui'             => true,
+				'query_var'           => true,
+				'menu_position'       => 20,
+				'supports'            => $supports_array,
+				'rewrite'             => array( 'slug' => $rewrite_slug, 'with_front' => false ),
 			)
 		);
 


### PR DESCRIPTION
- Simple URLs will no longer appear in search results by default (filterable, since some users indicated they do want the links able to appear in site's search results)
- Simple URLs post type will no longer display Yoast SEO metabox (since post type 'public' is now 'false')
- Added 'simple_urls_post_type_supports' filter so you can override post type's 'supports' argument. For example, to enable 'excerpts' to use for internal notes.
- Added data sanitization to custom slug (via 'simple_urls_slug' filter).

Closes https://github.com/copyblogger/simple-urls/issues/3
