### PR TITLE
Cast string to int to avoid type error

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -199,7 +199,7 @@ class SimpleURLs {
 		global $wp_query;
 
 		// Update the count
-		$count = isset( $wp_query->post->ID ) ? get_post_meta( $wp_query->post->ID, '_surl_count', true ) : 0;
+		$count = isset( $wp_query->post->_surl_count ) ? $wp_query->post->_surl_count : 0;
 		update_post_meta( $wp_query->post->ID, '_surl_count', $count + 1 );
 
 		// Handle the redirect

--- a/plugin.php
+++ b/plugin.php
@@ -199,7 +199,7 @@ class SimpleURLs {
 		global $wp_query;
 
 		// Update the count
-		$count = isset( $wp_query->post->_surl_count ) ? $wp_query->post->_surl_count : 0;
+		$count = isset( $wp_query->post->_surl_count ) ? (int) $wp_query->post->_surl_count : 0;
 		update_post_meta( $wp_query->post->ID, '_surl_count', $count + 1 );
 
 		// Handle the redirect


### PR DESCRIPTION
get_post_meta is not required as of WP 3.5: https://developer.wordpress.org/reference/functions/get_post_meta/#comment-1894

Accessing the property directly is a little neater, and casting to an int avoids the error reported in #10.